### PR TITLE
closing reponse body if client succeded

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -77,10 +77,10 @@ func (c *Client) Do(reqBody interface{}, successV interface{}) error {
 	}
 
 	resp, err := c.httpClient.Do(req)
-	defer closeRespBody(resp)
 	if err != nil {
 		return err
 	}
+	defer closeRespBody(resp)
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		if successV == nil {


### PR DESCRIPTION
response body may be nil if client failed
to connect with server

Signed-off-by: Oshank Kumar <okumar@redhat.com>